### PR TITLE
Use String, not Locale for value of EXTRA_LANGUAGE

### DIFF
--- a/app/src/main/java/org/vosk/service/ui/SpeechRecognizerActivity.java
+++ b/app/src/main/java/org/vosk/service/ui/SpeechRecognizerActivity.java
@@ -174,7 +174,7 @@ public class SpeechRecognizerActivity extends AppCompatActivity {
         final Intent speechRecognizerIntent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH);
         speechRecognizerIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL,
                 RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
-        speechRecognizerIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault());
+        speechRecognizerIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault().toString());
         speechRecognizer.startListening(speechRecognizerIntent);
     }
 


### PR DESCRIPTION
IIUC, `RecognizerIntent.EXTRA_LANGUAGE` should have an associated `String` value, not `Locale`.  From [the docs](https://developer.android.com/reference/android/speech/RecognizerIntent#EXTRA_LANGUAGE):

> Optional IETF language tag (as defined by BCP 47), for example "en-US".

[Here](https://stackoverflow.com/a/47187907) is an SO answer that is related.

I was seeing errors in logcat output regarding this -- one side effect of it was that a fallback value was getting used instead when instantiating something.