### PR TITLE
queries block for recongitionservice per google api

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,6 +7,12 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
+    <queries>
+        <intent>
+            <action android:name="android.speech.RecognitionService" />
+        </intent>
+    </queries>
+
     <application
         android:allowBackup="false"
         android:icon="@drawable/icon"


### PR DESCRIPTION
This is a fix to the android manifest that prevents bindings issues for the SpeechRecognizer. Prior to this fix, contemporary builds* would toast with a SpeechRecognizer loading error and logcat with an error similar to that described in #28 (_E - SpeechRecognizer - org.vosk.service - failure to bind to recognition service_; sorry... do not have the quoted logcat output).  

Per the Android API (for builds toward Android 11+; [see here](https://developer.android.com/training/package-visibility) ), this fix adds an explicit queries/intent block for RecognitionServices.

(At the time of this original merge request, #28 notes the same issue using a ?device with Android 9; but the compilesdk api level for the latest master is 33. Thus, #28 and this fix likely discuss the same error cases.)

The proposed changes eliminate the specified error, though still suffers from additional fatal run-time error addressed in #30 .

*The proposed change has been tested using:
**Source**: alphacep master [099198e](https://github.com/alphacep/vosk-android-service/commit/099198e5edd775287e6a5172680ce6619cca1e9c), current as of original merge request
**Build Configuration**: Gradle Toolkit command-line, debug w/universal apk (compilesdk 33)
**Gradle toolkit version**: 7.6 (defaults despite the build kts depending on 7.2.2; no api level spec'd); builds against OpenJDK-14
**Device**: Pixel 3
**Device OS**: Android 12
**Additional Device Apps**: AnySoftKeyboard (v1.11.7137/F-droid; UTD)
