### PR TITLE
replace underscore w/hypen per IETF

### DIFF
--- a/app/src/main/java/org/vosk/service/ui/SpeechRecognizerActivity.java
+++ b/app/src/main/java/org/vosk/service/ui/SpeechRecognizerActivity.java
@@ -174,7 +174,7 @@ public class SpeechRecognizerActivity extends AppCompatActivity {
         final Intent speechRecognizerIntent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH);
         speechRecognizerIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL,
                 RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
-        speechRecognizerIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault().toString());
+        speechRecognizerIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault().toString().replace("_","-"));
         speechRecognizer.startListening(speechRecognizerIntent);
     }
 


### PR DESCRIPTION
This fix covers @sogaiu 's fix in #25. Turns out using toString for the locale as proposed returns non IETF compatible strings:

> 
> 03-17 14:56:10.845  3792  3792 I SodaSpeechRecognizer: Offline recognizer - start listening
03-17 14:56:10.845  3792  3792 I SodaSpeechRecognizer: Initialize Soda [locale: **en_US**]
03-17 14:56:10.845  3792  3792 I AiAiSpeechRecognition: Get language pack info for en_US
03-17 14:56:10.890  1877  3858 W InputManager-JNI: Input channel object '3ce5040 com.google.android.permissioncontroller/com.android.permissioncontroller.permission.ui.GrantPermissionsActivity (client)' was disposed without first being removed with the input manager!
03-17 14:56:10.893  4848  4848 I KeyboardAwareLinearLayo: onKeyboardClose()
03-17 14:56:10.899  1350  6159 I AudioFlinger: AudioFlinger's thread 0x7171af7c60 tid=6159 ready to run
**03-17 14:56:10.910  3792  4087 E AiAiSpeechRecognition: Failed to get language pack from Superpacks for [en_US]. Error: 12; message: LPs for locales other than system locale is not downloadable**
03-17 14:56:10.911  3792 26702 I AiAiAudio: run(): Tee read loop starting
03-17 14:56:10.912  3792  4087 W AiAiSpeechRecognition: No sysimg LP for backup
03-17 14:56:10.913  3792  4239 E SodaSpeechRecognizer: Failed to get language pack of required locale: error 12

Adding the proposed changes + those from #29 make the service functional and able to be used with anysoftkeyboard*. There is a nagging run-time issue that does not affect operability that I will try to explore in the short-term.

The proposed change has been tested using and addresses the error above with:
**Source**: alphacep master [099198e](https://github.com/alphacep/vosk-android-service/commit/099198e5edd775287e6a5172680ce6619cca1e9c), current as of original merge request + changes proposed in #29 to cover issue from that PR
**Build Configuration**: Gradle Toolkit command-line, debug w/universal apk (compilesdk 33)
**Gradle toolkit version**: 7.6 (defaults despite the build kts depending on 7.2.2; no api level spec'd); builds against OpenJDK-14
**Device**: Pixel 3
**Device OS**: Android 12
**Additional Device Apps**: AnySoftKeyboard (v1.11.7137/F-droid; UTD)
