### PR TITLE
helper for starting listener to handle flow on initial permission request

### DIFF
--- a/app/src/main/java/org/vosk/service/ui/SpeechRecognizerActivity.java
+++ b/app/src/main/java/org/vosk/service/ui/SpeechRecognizerActivity.java
@@ -104,14 +104,18 @@ public class SpeechRecognizerActivity extends AppCompatActivity {
         Log.d(TAG, msg);
     }
 
+    void setupRecognizer() {
+        final Intent speechRecognizerIntent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH);
+        speechRecognizerIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+            RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
+        speechRecognizerIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault().toString().replace("_","-"));
+        speechRecognizer.startListening(speechRecognizerIntent);
+    }
+
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.speech_recognizer_activity);
-
-        if (!hasPermissions(this, PERMISSIONS)) {
-            ActivityCompat.requestPermissions(this, PERMISSIONS, PERMISSION_ALL);
-        }
 
         speechRecognizer = SpeechRecognizer.createSpeechRecognizer(this);
 
@@ -171,11 +175,13 @@ public class SpeechRecognizerActivity extends AppCompatActivity {
     public void onStart() {
         super.onStart();
         Log.i(TAG, "onStart");
-        final Intent speechRecognizerIntent = new Intent(RecognizerIntent.ACTION_RECOGNIZE_SPEECH);
-        speechRecognizerIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE_MODEL,
-                RecognizerIntent.LANGUAGE_MODEL_FREE_FORM);
-        speechRecognizerIntent.putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault().toString().replace("_","-"));
-        speechRecognizer.startListening(speechRecognizerIntent);
+
+        if (!hasPermissions(this, PERMISSIONS)) {
+            ActivityCompat.requestPermissions(this, PERMISSIONS, PERMISSION_ALL);
+        }
+        else {
+            setupRecognizer();
+        }
     }
 
     @Override
@@ -211,6 +217,7 @@ public class SpeechRecognizerActivity extends AppCompatActivity {
                 finish();
             }
         }
+        setupRecognizer();
     }
 
     private void returnResults(List<String> results) {


### PR DESCRIPTION
This is a combined issue/bugfix to fix a non-fatal bug. Prior to granting initial permissions for recording audio, the speech recognizer doesn't started properly.

Quering the service prior to getting permissions for the first time results in the error:
(t0)  2157  2256 I ActivityTaskManager: START u0 {act=android.content.pm.action.REQUEST_PERMISSIONS pkg=com.google.android.permissioncontroller cmp=com.google.android.permissioncontroller/com.android.permissioncontroller.permission.ui.GrantPermissionsActivity (has extras)} from uid 10475
(t0+eps) 15441 15441 I SpeechRecognizerActivity: onStart
(t0+eps)  2157  5219 W ActivityTaskManager: Tried to set launchTime (0) < mLastActivityLaunchTime (162296)
(t0+eps)  3595  3595 I RecognitionService: caller doesn't have permission:android.permission.RECORD_AUDIO

And the onError toast "error loading speechrecognizer". This is due to permissions being queried asynchronously by the request_permissions call, and the listener being started prior to getting permissions. The proposed fix uses a helper to block appropriately for permissions.

The proposed fix is stable with the good configuration:

**Source**: alphacep master 0b81fc5, current as of initial PR
**Build Configuration**: Gradle Toolkit command-line, debug w/universal apk (compilesdk 33)
**Gradle toolkit version**: 7.6 (defaults despite the build kts depending on 7.2.2; no api level spec'd); builds against OpenJDK-14
**Device**: Pixel 3
**Device OS**: Android 12
**Additional Device Apps**: AnySoftKeyboard (v1.11.7137/F-droid; UTD)

